### PR TITLE
Due to problems with Canary downloads through app, it's advisable to switch to direct GitHub links instead of using jsDelivr.

### DIFF
--- a/canary.json
+++ b/canary.json
@@ -2,11 +2,11 @@
   "magisk": {
     "version": "1dcf3255",
     "versionCode": "26402",
-    "link": "https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@7235d30bc73c16c953b1bc16e41bad1c962878c9/app-release.apk",
-    "note": "https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@7235d30bc73c16c953b1bc16e41bad1c962878c9/notes.md"
+    "link": "https://github.com/topjohnwu/magisk-files/raw/canary/app-release.apk",
+    "note": "https://raw.githubusercontent.com/topjohnwu/magisk-files/canary/notes.md"
   },
   "stub": {
     "versionCode": "38",
-    "link": "https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@7235d30bc73c16c953b1bc16e41bad1c962878c9/stub-release.apk"
+    "link": "https://github.com/topjohnwu/magisk-files/raw/canary/stub-release.apk"
   }
 }

--- a/debug.json
+++ b/debug.json
@@ -2,11 +2,11 @@
   "magisk": {
     "version": "1dcf3255",
     "versionCode": "26402",
-    "link": "https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@7235d30bc73c16c953b1bc16e41bad1c962878c9/app-debug.apk",
-    "note": "https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@7235d30bc73c16c953b1bc16e41bad1c962878c9/notes.md"
+    "link": "https://github.com/topjohnwu/magisk-files/raw/canary/app-debug.apk",
+    "note": "https://raw.githubusercontent.com/topjohnwu/magisk-files/canary/notes.md"
   },
   "stub": {
     "versionCode": "38",
-    "link": "https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@7235d30bc73c16c953b1bc16e41bad1c962878c9/stub-debug.apk"
+    "link": "https://github.com/topjohnwu/magisk-files/raw/canary/stub-debug.apk"
   }
 }


### PR DESCRIPTION
Recommend using direct links to avoid "File size exceeded the configured limit of 20 MB."
Alternatives include creating an issue on jsDelivr repo to get the limit increased.